### PR TITLE
Fix Node 15 Writable end() callback in tests

### DIFF
--- a/test/iomanager.test.js
+++ b/test/iomanager.test.js
@@ -106,10 +106,11 @@ describe('lib/iomanager.js', function () {
       const adapter = new MemoryAdapter()
       const obj = new IOManager(adapter, mockMiddlewareManager())
       expect(obj.createWriteStream('foo')).to.eventually.be.fulfilled.then(result => {
-        result.stream.end('passTest', () => {
+        result.stream.on('finish', () => {
           expect(adapter.read('foo', 'utf8')).to.eventually.equal('passTest')
             .notify(done)
         })
+        result.stream.end('passTest')
       })
     })
 
@@ -164,10 +165,11 @@ describe('lib/iomanager.js', function () {
       const adapter = new MemoryAdapter()
       const obj = new IOManager(adapter, mockMiddlewareManager())
       expect(obj.createTemporary('foo', {})).to.eventually.be.fulfilled.then(stream => {
-        stream.end('passTest', () => {
+        stream.on('finish', () => {
           expect(adapter.read('foo.tmp', 'utf8')).to.eventually.equal('passTest')
             .notify(done)
         })
+        stream.end('passTest')
       })
     })
 


### PR DESCRIPTION
Node 15 invokes the callback before the 'finish' event, previously leading to test failure.

Fixes #5