### PR TITLE
chore(tsconfig): Set "lib" explicitly to avoid DOM types in global

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ES2018"],
     "target": "es2018",
     "module": "commonjs",
     "esModuleInterop": true,


### PR DESCRIPTION
TSConfig "lib" by default includes DOM types which pollute the global namespace. This patch sets "lib" explicitly to avoid this behavior, which could lead to accidental bugs.