### PR TITLE
test: Mark Promise-returning functions as async

### DIFF
--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -205,11 +205,11 @@ describe('lib/db.ts', function () {
         'qux.json': Buffer.from('{}')
       }))
       let removed: string | undefined
-      await obj.each((item) => {
+      await obj.each(async (item) => {
         if (removed == null) {
           // pick any item other than the current
           removed = item.id === 'foo' ? 'bar' : 'foo'
-          return obj.remove(removed)
+          return await obj.remove(removed)
         }
         assert.notStrictEqual(item.id, removed)
       })

--- a/test/idset.test.ts
+++ b/test/idset.test.ts
@@ -85,11 +85,11 @@ describe('lib/idset.ts', function () {
     it('allows for element removal', async function () {
       const obj = new IdSet(() => ['AB', 'CD', 'EF'])
       let removed: string | undefined
-      await obj.each((id) => {
+      await obj.each(async (id) => {
         if (removed == null) {
           // pick any item other than the current
           removed = id === 'AB' ? 'CD' : 'AB'
-          return obj.remove(removed)
+          return await obj.remove(removed)
         }
         assert.notStrictEqual(id, removed)
       })


### PR DESCRIPTION
This fixes a linter error in an upcoming update to typescript-eslint.