### PR TITLE
chore!: Drop support for Node.js older than v18.16.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,8 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 20
           - 18
-          - 16
-          - 14
-          - 12
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "typescript": "5.0.4"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.16.1"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/meyfa/giantdb",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=18.16.1"
   },
   "devDependencies": {
     "@meyfa/eslint-config": "3.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["ES2018"],
-    "target": "es2018",
+    "lib": ["ES2022"],
+    "target": "es2022",
     "module": "commonjs",
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Node.js v18.16.1 is the most recent LTS version at this time. v12 and v14 are already at end-of-life, and v16 will reach end-of-life on 2023-09-11.